### PR TITLE
Remove version from show-plugin btest in prep for 2.7

### DIFF
--- a/tests/Baseline/scripts.show-plugin/output
+++ b/tests/Baseline/scripts.show-plugin/output
@@ -1,4 +1,4 @@
-JGras::FuzzyHashing - Fuzzy hashing support for Bro (dynamic, version 0.3)
+JGras::FuzzyHashing - Fuzzy hashing support for Bro (dynamic, version)
     [File Analyzer] SSDeep (ANALYZER_SSDEEP)
     [File Analyzer] TLSH (ANALYZER_TLSH)
     [Event] file_fuzzy_hash

--- a/tests/scripts/show-plugin.bro
+++ b/tests/scripts/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN JGras::FuzzyHashing >output
+# @TEST-EXEC: bro -NN JGras::FuzzyHashing |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.